### PR TITLE
Do not require second parameter in root DSL method

### DIFF
--- a/lib/grape/jsonapi/entity/resource.rb
+++ b/lib/grape/jsonapi/entity/resource.rb
@@ -30,7 +30,7 @@ module Grape
           end
         end
 
-        def self.root(plural, _singular)
+        def self.root(plural, _singular = nil)
           @type_plural = plural
         end
 


### PR DESCRIPTION
Current code doesn't make much sense, as this second parameter isn't used anyway.

But we need to leave it there for backwards compatibility reasons.